### PR TITLE
adding visible prop for lastIdentity and short-circuit set identity call

### DIFF
--- a/KISSMetricsAPI.h
+++ b/KISSMetricsAPI.h
@@ -16,6 +16,7 @@
 
 @interface KISSMetricsAPI : NSObject
 
+@property (nonatomic, retain) NSString *lastIdentity;
 
 /**
  * sharedAPIWithKey:

--- a/KISSMetricsAPI.m
+++ b/KISSMetricsAPI.m
@@ -41,7 +41,6 @@ static KISSMetricsAPI *sharedAPI = nil;
 @property (nonatomic, retain) NSTimer *timer;
 @property (nonatomic, retain) NSURLConnection *existingConnection;
 @property (nonatomic, retain) NSString *key;
-@property (nonatomic, retain) NSString *lastIdentity;
 @property (nonatomic, retain) NSDictionary *propsToSend;
 @property (nonatomic, readwrite) NSInteger failureStatus;
 
@@ -656,7 +655,10 @@ static KISSMetricsAPI *sharedAPI = nil;
         InfoLog(@"KISSMetricsAPI: WARNING - attempted to use nil or empty identity. Ignoring.");
         return;
     }
-    
+  
+    if ([lastIdentity isEqualToString:identity])
+      return;
+  
     
     NSString *escapedOldIdentity = [self urlEncode:self.lastIdentity];
     NSString *escapedNewIdentity = [self urlEncode:identity];


### PR DESCRIPTION
hello, I needed to access the value of lastIdentity to send the id in a url, i.e.:

http://www.mysite.com/api/v1/example?unique_id=123ABC

so I moved the property declaration to the .h file.

Also, I wanted to be able to call the identity method with a value and NOT have it really make an http call to the kiss metrics api if the value I pass in is already what lastIdentity is set to.  i.e. don't make kiss metrics report 'bob has been alias to bob' which it does if I call identity(@"bob") and it was already bob.  thanks! 
